### PR TITLE
Added link to the gallery in modrinth

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ You can now select `Stracciatella` (same name as the folder) from within Minecra
 
 ### Fog and Sky
 
+[Gallery](https://modrinth.com/shader/stracciatella-shaders/gallery)
+
 - Sun and Moon Size
 - Sun Angle
 - Horizon Cutoff for Sun and Moon


### PR DESCRIPTION
if you came to the github page and are looking for screenshots, youd have to search for it by name, which is a hassle. better to have a link right there.